### PR TITLE
Allowing building with the 4.0 SDK.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "resources": {
       "media": []
     },
-    "messageKeys": {}
+    "messageKeys": []
   }
 }


### PR DESCRIPTION
Fixes the ''pebble-gbitmap-lib' has an invalid messageKeys object. Libraries can only specify an messageKeys array.' error when building with  the SDK v4.0
